### PR TITLE
Rendre compatible avec Symfony 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       matrix:
         php-version: [ '7.4', '8.0', '8.1' ]
-        symfony-version: ['^4.4', '^5.0', '^5.3']
+        symfony-version: ['^4.4', '^5.0', '^5.3', '^6.0']
+        exclude:
+                - php-version: '7.4'
+                  symfony-version: '^6.0'
       fail-fast: false
     steps:
       - uses: actions/checkout@master

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     "require-dev": {
         "atoum/atoum":                      "^4.0",
         "m6web/php-cs-fixer-config":        "^2.0",
-        "symfony/dependency-injection":     "^4.4||^5.0",
-        "symfony/event-dispatcher":         "^4.4||^5.0",
-        "symfony/config":                   "^4.4||^5.0",
-        "symfony/yaml":                     "^4.4||^5.0",
-        "symfony/http-foundation":          "^4.4||^5.0",
-        "symfony/http-kernel":              "^4.4||^5.0"
+        "symfony/dependency-injection":     "^4.4||^5.0||^6.0",
+        "symfony/event-dispatcher":         "^4.4||^5.0||^6.0",
+        "symfony/config":                   "^4.4||^5.0||^6.0",
+        "symfony/yaml":                     "^4.4||^5.0||^6.0",
+        "symfony/http-foundation":          "^4.4||^5.0||^6.0",
+        "symfony/http-kernel":              "^4.4||^5.0||^6.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/DependencyInjection/M6WebElasticsearchExtension.php
@@ -41,10 +41,7 @@ class M6WebElasticsearchExtension extends Extension
         }
     }
 
-    /**
-     * @return string
-     */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'm6web_elasticsearch';
     }

--- a/src/M6Web/Bundle/ElasticsearchBundle/M6WebElasticsearchBundle.php
+++ b/src/M6Web/Bundle/ElasticsearchBundle/M6WebElasticsearchBundle.php
@@ -2,6 +2,7 @@
 
 namespace M6Web\Bundle\ElasticsearchBundle;
 
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -12,7 +13,7 @@ class M6WebElasticsearchBundle extends Bundle
     /**
      * @return DependencyInjection\M6WebElasticsearchExtension|\Symfony\Component\DependencyInjection\Extension\ExtensionInterface|null
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new DependencyInjection\M6WebElasticsearchExtension();
     }


### PR DESCRIPTION
Environnement : Mac OS X
PHP Version : 8.1.3
Symfony version : 6.0.6
Version du bundle installée : 3.0.0

Lors de l'intégration du bundle avec Symfony 6.0, deux messages d'erreur remontaient lors du `composer require` / `clear:cache` :

* `Declaration of M6Web\Bundle\ElasticsearchBundle\M6WebElasticsearchBundle::getContainerExtension() must be compatible with Symfony\Component\HttpKernel\Bundle\Bundle::getContainerExtension(): ?Symfony\Component\DependencyInjection\Extension\ExtensionInterface`

* `Declaration of M6Web\Bundle\ElasticsearchBundle\DependencyInjection\M6WebElasticsearchExtension::getAlias() must be compatible with Symfony\Component\DependencyInjection\Extension\Extension::getAlias(): string`