### PR TITLE
fix: fix cs-fixer-config version to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "atoum/atoum":                      "^4.0",
-        "m6web/php-cs-fixer-config":        "^2.0",
+        "m6web/php-cs-fixer-config":        "2.0",
         "symfony/dependency-injection":     "^4.4||^5.0||^6.0",
         "symfony/event-dispatcher":         "^4.4||^5.0||^6.0",
         "symfony/config":                   "^4.4||^5.0||^6.0",


### PR DESCRIPTION
## Why
Since the update of [m6web/php-cs-fixer-config](https://github.com/BedrockStreaming/php-cs-fixer-config/releases/tag/v2.1.0), CI is broken

## How
Fix the version of `cs-fixer-config`.

## Release
Release as a fix version.